### PR TITLE
【Fixed】【ユーザー機能】facebookログインできるようにする

### DIFF
--- a/app/assets/javascripts/users/omniauth_callbacks.coffee
+++ b/app/assets/javascripts/users/omniauth_callbacks.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/users/registrations.coffee
+++ b/app/assets/javascripts/users/registrations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users/omniauth_callbacks.scss
+++ b/app/assets/stylesheets/users/omniauth_callbacks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users::OmniauthCallbacks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/users/registrations.scss
+++ b/app/assets/stylesheets/users/registrations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users::registrations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,13 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def facebook
+    @user = User.find_for_facebook_oauth(request.env["omniauth.auth"], current_user)
+
+    if @user.persisted?
+      set_flash_message(:notice, :success, kind: "Facebook") if is_navigational_format?
+      sign_in_and_redirect @user, event: :authentication
+    else
+      session["devise.facebook_data"] = request.env["omniauth.auth"]
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,6 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  def build_resource(hash=nil)
+    hash[:uid] = User.create_unique_string
+    super
+  end
+end

--- a/app/helpers/users/omniauth_callbacks_helper.rb
+++ b/app/helpers/users/omniauth_callbacks_helper.rb
@@ -1,0 +1,2 @@
+module Users::OmniauthCallbacksHelper
+end

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,2 @@
+module Users::RegistrationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,26 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
+
+  def self.find_for_facebook_oauth(auth, signed_in_resource=nil)
+    user = User.where(provider: auth.provider, uid: auth.uid).first
+
+    unless user
+      user = User.new(
+          name:     auth.extra.raw_info.name,
+          provider: auth.provider,
+          uid:      auth.uid,
+          email:    auth.info.email ||= "#{auth.uid}-#{auth.provider}@example.com",
+          image_url:   auth.info.image,
+          password: Devise.friendly_token[0, 20]
+      )
+      #user.skip_confirmation!
+      user.save(validate: false)
+    end
+    user
+  end
+
+  def self.create_unique_string
+    SecureRandom.uuid
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -271,4 +271,9 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+  if Rails.env.production?
+    config.omniauth :facebook, ENV["FACEBOOK_ID_PRODUCTION"], ENV["FACEBOOK_SECRET_PRODUCTION"], scope: 'email', display: 'popup', info_fields: 'name, email'
+  else
+    config.omniauth :facebook, ENV["FACEBOOK_ID_DEVELOPMENT"], ENV["FACEBOOK_SECRET_DEVELOPMENT"], scope: 'email', display: 'popup', info_fields: 'name, email'
+  end
 end

--- a/db/migrate/20161009125542_devise_create_users.rb
+++ b/db/migrate/20161009125542_devise_create_users.rb
@@ -33,7 +33,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
       t.string :uid,      null: false, default: ""
       t.string :provider, null: false, default: ""
       t.string :name, null: false, default: '変更してください'
-      t.string :image
+      t.string :image_url
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20161009125542) do
     t.string   "uid",                    default: "",         null: false
     t.string   "provider",               default: "",         null: false
     t.string   "name",                   default: "変更してください", null: false
-    t.string   "image"
+    t.string   "image_url"
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false
   end

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Users::OmniauthCallbacksControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Users::RegistrationsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#41
### Facebookでのログイン及び新規登録ができるようにする
- [ ] Facebookにて下記アプリケーション登録実施。
  　　dic_stackoverflow_development
  　　dic_stackoverflow_production
- [ ] config/initializers/devise.rb を編集。
- [ ] .envにIDとキーを追記する。
- [ ] rails g controller users::OmniauthCallbacks を実行。
- [ ] users/OmniauthCallbacksController.rb の継承元を
- [ ] Devise::OmniauthCallbacksController　に修正。
- [ ] users/OmniauthCallbacksController.rb にfacebookメソッドを定義。
- [ ] app/models/user.rb にfind_for_facebook_oauthを定義。
     ※テーブル作成時のカラム名が誤っていたため、マイグレーションファイルを下記の通り修正
  　image　->　image_url
### 通常の新規登録ができるようにする
- [ ] rails g controller users::registrations を実行。
- [ ] app/controllers/users/registration_controller.rb の内容を追加。
- [ ] app/models/user.rb　に　create_unique_stringメソッドを定義。
