### PR TITLE
【Fix】タグ一覧ページを作成する

### DIFF
--- a/app/assets/javascripts/tags.coffee
+++ b/app/assets/javascripts/tags.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the tags controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,5 @@
+class TagsController < ApplicationController
+  def index
+    @tags = Tag.all
+  end
+end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,2 @@
+module TagsHelper
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ActiveRecord::Base
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
     <h1><img src="<%= asset_path "logo02.png" %>"></h1>
     <ul class="top">
       <li><%= link_to '質問', questions_path %></li>
-      <li><%= link_to 'タグ', "#" %></li>
+      <li><%= link_to 'タグ', tags_path %></li>
       <li><%= link_to 'ユーザ', users_path %></li>
       <li><%= link_to 'バッジ', "#" %></li>
       <li><%= link_to '未回答', "#" %></li>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -15,9 +15,8 @@
 </div>
 
 <div class="form-group">
- <% f.label :tag_list ,"タグ" %>
+ <%= f.label :tag_list ,"タグ" %>
  <%= text_field_tag 'question[tag_list]', @question.tag_list.join(',') , class: "form-control" , rows: "10"%>
- <% f.text_field :content , class: "form-control" , rows: "10"%>
 </div>
 
   <%= f.submit "質問を投稿する",class:"btn btn-primary" %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+    <div class="col-sm-10 col-sm-offset-1 user_index">
+      <h4>タグ</h4>
+      <hr>
+
+<% @tags.each do |tag| %>
+  <p class="user">
+  <span class="label label-primary"><%= link_to tag.name,questions_path(tag: tag.name),style: "color:white;" %></span>
+  x <%= tag.taggings_count %>
+  </p>
+<% end %>
+
+</div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+
 #トップ画面
   root 'top#index'
 
@@ -9,6 +10,7 @@ Rails.application.routes.draw do
   }
   resources :users, only: [:index,:show]
   resources :favorites, only: [:create,:destroy]
+  resources :tags, only: [:index]
 #質問機能
   resources :questions do
     resources :answers

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class TagsControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
#143 
下記実装しました。
- [ ] タグコントローラを実装
- [ ] ルーティング生成
- [ ] トップページにリンクを生成
- [ ] ビューファイルを実装